### PR TITLE
Add support for more results per page

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ const opts = {
   // prefill user input
   prefill: '',
 
+  // desired quantity of results per page (defaults to 6)
+  maxResults: 6,
+
   // text before each displayed line, list index supplied as arg
   prelinehook: function ( index ) { return '' },
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const opts = {
   prefill: '',
 
   // text before each displayed line, list index supplied as arg
-  prelinehook: function ( index ) { return '' }
+  prelinehook: function ( index ) { return '' },
 
   // text after each displayed line, list index supplied as arg
   postlinehook: function ( index ) { return '' }

--- a/src/main.js
+++ b/src/main.js
@@ -153,7 +153,7 @@ function queryUser ( opts, callback )
     let _matches = []
     let _selectedItem
 
-    const MIN_HEIGHT = 6
+    const MIN_HEIGHT = _opts.maxResults || 6
 
     function getMaxWidth () {
       const mx = stdout.columns - 7


### PR DESCRIPTION
Allows opts to have a `maxResults` key to change the number of items displayed into a single page
```js
const opts = {
  /* required */
  list: [ 'whale', 'giraffe', 'monkey' ],

  /* optional (and defaults) */
  // filtering mode (user can change modes by pressing ctrl-s)
  mode: 'fuzzy' || 'normal',

  // prefill user input
  prefill: '',

  // desired quantity of results per page (defaults to 6)
  maxResults: 6,

  // text before each displayed line, list index supplied as arg
  prelinehook: function ( index ) { return '' },

  // text after each displayed line, list index supplied as arg
  postlinehook: function ( index ) { return '' }
}
```

Example with 30 results per page
![image](https://github.com/user-attachments/assets/563ea55b-3978-46d3-873b-14753a01c998)


tested with 1500 items in memory and adds no lag at all
Also it does not break compatibility since by default falls back to previous behaviour.
![image](https://github.com/user-attachments/assets/86ed4839-9359-4466-a729-1954d1e13bfc)
