### PR TITLE
chore: replace `string-width` w/ `fast-string-width`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "email": "talmo.christian@gmail.com"
   },
   "dependencies": {
+    "fast-string-width": "^1.1.0",
     "keypress": "~0.2.1",
     "minimist": "~1.2.5",
     "picocolors": "~1.1.1",
     "redstar": "0.0.2",
     "restore-cursor": "~3.1.0",
-    "string-width": "~2.1.1",
     "ttys": "0.0.3",
     "window-size": "~1.1.1"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ const ansiRegex = function() {
 // get printed width of text
 // ex. 漢字 are 4 characters wide but still
 // only 2 characters in length
-const _stringWidth = require( 'string-width' )
+const { default: _stringWidth } = require( 'fast-string-width' )
 function stringWidth ( str ) {
   return Math.max( str.replace(ansiRegex, '').length, _stringWidth( str ) )
 }


### PR DESCRIPTION
As the name implies, `fast-string-width` is faster. But most importantly, `fast-string-width` is way smaller:

- `fast-string-width`: `24 KiB` https://pkg-size.dev/fast-string-width 
- `string-width`: `65 KiB` https://pkg-size.dev/string-width